### PR TITLE
プロトタイプ編集機能

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
       responders
       warden (~> 1.2.3)
     erubi (1.13.0)
+    ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -144,6 +145,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.16.7-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -259,6 +262,7 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -23,6 +23,17 @@ class PrototypesController < ApplicationController
   def show
   end
 
+  def edit
+  end
+
+  def update
+    if @prototype.update(prototype_params)
+      redirect_to prototype_path(params[:id])
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def prototype_params
@@ -34,7 +45,7 @@ class PrototypesController < ApplicationController
   end
 
   def move_to_index
-    return if user_signed_in? && current_user.id == @item.user_id
+    return if user_signed_in? && current_user.id == @prototype.user_id
 
     redirect_to root_path
   end

--- a/app/views/prototypes/_form.html.erb
+++ b/app/views/prototypes/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @prototype, local: true do |f|%>
+<%= form_with model: prototype, local: true do |f|%>
   <div class="field">
     <%= f.label :title, "プロトタイプの名称" %><br />
     <%= f.text_field :title, id:"prototype_title" %>

--- a/app/views/prototypes/edit.html.erb
+++ b/app/views/prototypes/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="form__wrapper">
       <h2 class="page-heading">プロトタイプ編集</h2>
-      <%# 部分テンプレートでフォームを表示する %>
+      <%= render partial:"form", locals: { prototype: @prototype }%>
     </div>
   </div>
 </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -8,7 +8,7 @@
 
       <% if user_signed_in? && current_user == @prototype.user %>
         <div class="prototype__manage">
-          <%= link_to "編集する", root_path, class: :prototype__btn %>
+          <%= link_to "編集する", edit_prototype_path(@prototype.id), class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
         </div>
       <% end %>


### PR DESCRIPTION
# What
edit,updateアクションの定義
プロトタイプ編集ページの作成

# Why
プロトタイプを作成者が編集できるようにするため。

# 挙動確認のgyazo
ログイン状態の投稿者は、プロトタイプ情報編集ページに遷移できる動画
https://gyazo.com/32350f2ca4362fec13ca3fe2d2831849

必要な情報を適切に入力して「保存する」ボタンを押すと、プロトタイプの情報を編集できる動画
https://gyazo.com/448998fcc03d8af000abc846f6bf1dad

入力に問題がある状態で「保存する」ボタンが押された場合、情報は保存されず、そのページに留まる動画
https://gyazo.com/08df5320cabd196bffb03ce7cb086a55

何も編集せずに「保存する」ボタンを押しても、画像無しのプロトタイプにならない動画
https://gyazo.com/5378a7a1502e48ca2f6d5bfa16f4761e

ログイン状態の場合でも、URLを直接入力して自身が投稿していないプロトタイプのプロトタイプ情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/182dcfa3472bfe2a142077a84ef15742

ログアウト状態の場合は、URLを直接入力してプロトタイプ情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/4c15cbe2aeb932d0a1ba31164fe25bd4

プロトタイプ情報について、すでに登録されている情報は、編集画面を開いた時点で表示される動画
https://gyazo.com/32350f2ca4362fec13ca3fe2d2831849